### PR TITLE
expose unsafeInterpret

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,4 +17,5 @@ Jens Petersen
 Mark Wright
 Nathaniel W. Filardo
 Pasqualino Titto Assini
+Rob Zinkov <rob@zinkov.com>
 Samuel Gélineau

--- a/src/Hint/Eval.hs
+++ b/src/Hint/Eval.hs
@@ -1,5 +1,6 @@
 module Hint.Eval (
       interpret, as, infer,
+      unsafeInterpret,
       eval, parens
 ) where
 

--- a/src/Language/Haskell/Interpreter/Unsafe.hs
+++ b/src/Language/Haskell/Interpreter/Unsafe.hs
@@ -1,11 +1,13 @@
 module Language.Haskell.Interpreter.Unsafe (
-    unsafeSetGhcOption, unsafeRunInterpreterWithArgs
+    unsafeSetGhcOption, unsafeRunInterpreterWithArgs,
+    unsafeInterpret
 ) where
 
 import Control.Monad.Trans
 import Control.Monad.Catch
 
 import Hint.Base
+import Hint.Eval
 import Hint.Configuration
 import Hint.InterpreterT
 


### PR DESCRIPTION
There are uses of hint where giving a type hint is the only way it is possible for code to
typecheck. As an example, hakaru uses un-exposed functionality to parse Haskell code
which makes use of finally tagless interpreters, and needs the type annotations to run

https://github.com/hakaru-dev/hakaru/blob/v0.2.0/Language/Hakaru/Simplify.hs#L98