### PR TITLE
make hint work in dynamic executables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ matrix:
       addons: {apt: {packages: [cabal-install-1.22, ghc-7.10.3], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.1
       addons: {apt: {packages: [cabal-install-1.24, ghc-8.0.1],  sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=8.0.1 DYNAMIC=--enable-executable-dynamic
+      addons: {apt: {packages: [cabal-install-1.24, ghc-8.0.1],  sources: [hvr-ghc]}}
 
 before_install:
   - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
@@ -17,7 +19,7 @@ install:
   - cabal install --only-dependencies --enable-tests
 
 script:
-  - cabal configure --enable-tests
+  - cabal configure --enable-tests $DYNAMIC
   - cabal build
   - cabal test
   - cabal install

--- a/src/Hint/Compat.hs
+++ b/src/Hint/Compat.hs
@@ -16,7 +16,11 @@ supportedExtensions = map f GHC.xFlags
 #endif
 
 configureDynFlags :: GHC.DynFlags -> GHC.DynFlags
-configureDynFlags dflags = dflags{GHC.ghcMode    = GHC.CompManager,
+configureDynFlags dflags =
+#if __GLASGOW_HASKELL__ >= 708
+    (if GHC.dynamicGhc then GHC.addWay' GHC.WayDyn else id)
+#endif
+                           dflags{GHC.ghcMode    = GHC.CompManager,
                                   GHC.hscTarget  = GHC.HscInterpreted,
                                   GHC.ghcLink    = GHC.LinkInMemory,
                                   GHC.verbosity  = 0}

--- a/src/Hint/GHC.hs
+++ b/src/Hint/GHC.hs
@@ -25,6 +25,10 @@ import DynFlags as X (xFlags, xopt, LogAction, FlagSpec(..))
 import DynFlags as X (xFlags, xopt, LogAction)
 #endif
 
+#if __GLASGOW_HASKELL__ >= 800
+import DynFlags as X (WarnReason(NoReason))
+#endif
+
 import PprTyThing as X (pprTypeForUser)
 import SrcLoc as X (mkRealSrcLoc)
 

--- a/src/Hint/GHC.hs
+++ b/src/Hint/GHC.hs
@@ -36,4 +36,8 @@ import SrcLoc as X (mkRealSrcLoc)
 import ConLike as X (ConLike(RealDataCon))
 #endif
 
+#if __GLASGOW_HASKELL__ >= 708
+import DynFlags as X (addWay', Way(..), dynamicGhc)
+#endif
+
 type Message = MsgDoc

--- a/src/Hint/Parsers.hs
+++ b/src/Hint/Parsers.hs
@@ -8,10 +8,6 @@ import Control.Monad.Trans (liftIO)
 
 import qualified Hint.GHC as GHC
 
-#if __GLASGOW_HASKELL__ >= 800
-import qualified DynFlags as GHC
-#endif
-
 data ParseResult = ParseOk | ParseError GHC.SrcSpan GHC.Message
 
 parseExpr :: MonadInterpreter m => String -> m ParseResult


### PR DESCRIPTION
`hint` currently only works when linked statically. it fails when linked dynamically because it will target the vanilla way independently of whether the dynamic runtime is in use.

the second patch here changes this (the first one is a minor cleanup for #16)
