### PR TITLE
Add normalizeType

### DIFF
--- a/src/Hint/Typecheck.hs
+++ b/src/Hint/Typecheck.hs
@@ -1,5 +1,5 @@
 module Hint.Typecheck (
-      typeOf, typeChecks, kindOf,
+      typeOf, typeChecks, kindOf, normalizeType
 ) where
 
 import Control.Monad.Catch
@@ -37,17 +37,30 @@ kindOf type_expr =
        -- kind of errors
        failOnParseError parseType type_expr
        --
-       kind <- mayFail $ runGhc1 typeKind type_expr
+       (_, kind) <- mayFail $ runGhc1 typeKind type_expr
        --
        kindToString (Compat.Kind kind)
+
+-- | Returns a string representation of the normalized type expression.
+-- This is what the @:kind!@ GHCi command prints after @=@.
+normalizeType :: MonadInterpreter m => String -> m String
+normalizeType type_expr =
+    do -- First, make sure the expression has no syntax errors,
+       -- for this is the only way we have to "intercept" this
+       -- kind of errors
+       failOnParseError parseType type_expr
+       --
+       (ty, _) <- mayFail $ runGhc1 typeKind type_expr
+       --
+       typeToString ty
 
 -- add a bogus Maybe, in order to use it with mayFail
 exprType :: GHC.GhcMonad m => String -> m (Maybe GHC.Type)
 exprType = fmap Just . GHC.exprType
 
 -- add a bogus Maybe, in order to use it with mayFail
-typeKind :: GHC.GhcMonad m => String -> m (Maybe GHC.Kind)
-typeKind = fmap (Just . snd) . GHC.typeKind True
+typeKind :: GHC.GhcMonad m => String -> m (Maybe (GHC.Type, GHC.Kind))
+typeKind = fmap Just . GHC.typeKind True
 
 onCompilationError :: MonadInterpreter m
                    => ([GhcError] -> m a)

--- a/src/Language/Haskell/Interpreter.hs
+++ b/src/Language/Haskell/Interpreter.hs
@@ -34,7 +34,7 @@ module Language.Haskell.Interpreter(
     -- pragmas inline in the code since GHC scarfs them up.
     getModuleAnnotations, getValAnnotations,
     -- ** Type inference
-     typeOf, typeChecks, kindOf,
+     typeOf, typeChecks, kindOf, normalizeType,
     -- ** Evaluation
      interpret, as, infer, eval,
     -- * Error handling

--- a/unit-tests/run-unit-tests.hs
+++ b/unit-tests/run-unit-tests.hs
@@ -200,6 +200,19 @@ test_only_one_instance = TestCase "only_one_instance" [] $ liftIO $ do
         _ <- forkIO $ Control.Monad.void concurrent
         readMVar r @?  "concurrent instance did not fail"
 
+test_normalize_type :: TestCase
+test_normalize_type = TestCase "normalize_type" [mod_file] $ do
+        liftIO $ writeFile mod_file mod_text
+        loadModules [mod_file]
+        setTopLevelModules ["T"]
+        normalizeType "Foo Int" @@?= "()"
+
+    where mod_text = unlines ["{-# LANGUAGE TypeFamilies #-}"
+                             ,"module T where"
+                             ,"type family Foo x"
+                             ,"type instance Foo x = ()"]
+          mod_file = "TEST_NormalizeType.hs"
+
 tests :: [TestCase]
 tests = [test_reload_modified
         ,test_lang_exts
@@ -215,6 +228,7 @@ tests = [test_reload_modified
         ,test_search_path_dot
         ,test_catch
         ,test_only_one_instance
+        ,test_normalize_type
         ]
 
 main :: IO ()


### PR DESCRIPTION
Sometimes it's useful to evaluate type-level expressions. The `normalizeType` function provides that.