### PR TITLE
Make `examples.hs` link work in Hackage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ API.
 
 ### Example
 
-Check [./examples/example.hs](https://github.com/mvdan/hint/blob/master/examples/example.hs) to see a simple but
+Check [examples/example.hs](https://github.com/mvdan/hint/blob/HEAD/examples/example.hs) to see a simple but
 comprehensive example (it must be run from the `examples` directory).

--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ API.
 
 ### Example
 
-Check [example.hs](examples/example.hs) to see a simple but
+Check [./examples/example.hs](https://github.com/mvdan/hint/blob/master/examples/example.hs) to see a simple but
 comprehensive example (it must be run from the `examples` directory).


### PR DESCRIPTION
The old relative link worked when the readme was rendered on GitHub (https://github.com/mvdan/hint) but not when rendered on Hackage (http://hackage.haskell.org/package/hint-0.6.0). So, I changed the link to be an absolute link to the GitHub version, and changed the anchor text to be the relative path, so the user knows where to look if they're reading the readme from a working copy of the Git repo or `cabal unpack hint` or whatever.