### PR TITLE
fix build with ghc-8.2 (#32)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ matrix:
       addons: {apt: {packages: [cabal-install-1.22, ghc-7.10.3], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.2
       addons: {apt: {packages: [cabal-install-1.24, ghc-8.0.2],  sources: [hvr-ghc]}}
+    - env: CABALVER=2.0 GHCVER=8.2.1
+      addons: {apt: {packages: [cabal-install-2.0, ghc-8.2.1],  sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.2 DYNAMIC=--enable-executable-dynamic
       addons: {apt: {packages: [cabal-install-1.24, ghc-8.0.2],  sources: [hvr-ghc]}}
 

--- a/hint.cabal
+++ b/hint.cabal
@@ -45,7 +45,7 @@ Test-Suite unit-tests
 
 Library
   build-depends: base == 4.*,
-                 ghc >= 7.6 && < 8.2,
+                 ghc >= 7.6 && < 8.4,
                  ghc-paths,
                  mtl,
                  filepath,

--- a/src/Hint/Typecheck.hs
+++ b/src/Hint/Typecheck.hs
@@ -56,7 +56,11 @@ normalizeType type_expr =
 
 -- add a bogus Maybe, in order to use it with mayFail
 exprType :: GHC.GhcMonad m => String -> m (Maybe GHC.Type)
+#if __GLASGOW_HASKELL__ < 802
 exprType = fmap Just . GHC.exprType
+#else
+exprType = fmap Just . GHC.exprType GHC.TM_Inst
+#endif
 
 -- add a bogus Maybe, in order to use it with mayFail
 typeKind :: GHC.GhcMonad m => String -> m (Maybe (GHC.Type, GHC.Kind))


### PR DESCRIPTION
The fallout looks small this time, `GHC.exprType` has an extra argument now. See also #32.