### PR TITLE
Add `runStmt` for executing IO statements and binding new names

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,6 +12,7 @@ Daniel Wagner
 Evan Laforge
 Fernando Benavides
 Gwern Branwen
+Heinrich Apfelmus
 Jean Philippe Bernardy
 Jens Petersen
 Mark Wright

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Upcoming release
+
+* Add `runStmt` for executing statements in the `IO` monad and binding new names.
+
 ### 0.7.0
 
 * Support for GHC 8.2

--- a/examples/example.hs
+++ b/examples/example.hs
@@ -68,3 +68,10 @@ testHint =
       say "Here we evaluate an expression of type string, that when evaluated (again) leads to a string"
       res <- interpret "head $ map show [\"Worked!\", \"Didn't work\"]" infer >>= flip interpret infer
       say res
+      emptyLine
+      say "We can also execute statements in the IO monad and bind new names, e.g."
+      let stmts = ["x <- return 42", "print x"]
+      forM_ stmts $ \s -> do
+          say $ "    " ++ s
+          runStmt s
+      emptyLine

--- a/src/Language/Haskell/Interpreter.hs
+++ b/src/Language/Haskell/Interpreter.hs
@@ -36,7 +36,7 @@ module Language.Haskell.Interpreter(
     -- ** Type inference
      typeOf, typeChecks, kindOf, normalizeType,
     -- ** Evaluation
-     interpret, as, infer, eval,
+     interpret, as, infer, eval, runStmt,
     -- * Error handling
      InterpreterError(..), GhcError(..), MultipleInstancesNotAllowed(..),
     -- * Miscellaneous


### PR DESCRIPTION
Hello Daniel, thanks for maintaining `hint`!

My project [HyperHaskell][1] is built on the `hint` library. In order to be as useful as the command line GHCi, I need the ability to bind names and execute statements in the `IO` monad, e.g. the ability to interpret things like

    x <- return 42
    print x

For this reason, I have implemented a wrapper around the `runStmt` function from the GHC API, and would like to see it included in the `hint` library, hence this pull request.

  [1]: https://github.com/HeinrichApfelmus/hyper-haskell