### PR TITLE
Tighten lower bound on ghc

### DIFF
--- a/hint.cabal
+++ b/hint.cabal
@@ -45,7 +45,7 @@ test-suite unit-tests
 
 library
   build-depends: base == 4.*,
-                 ghc >= 7.6 && < 8.4,
+                 ghc >= 7.8 && < 8.4,
                  ghc-paths,
                  mtl,
                  filepath,


### PR DESCRIPTION
hint-0.7 dropped support for GHC 7.6, however the `hint.cabal` file wasn't updated accordingly, so that cabal wouldn't know that hint-0.7 isn't compatible w/ GHC 7.6 and run into the build failure below:

```
Configuring component lib from hint-0.7.0...
Preprocessing library hint-0.7.0...

src/Hint/GHC.hs:35:8:
    Could not find module `ConLike'
    Use -v to see a list of the files searched for.
```

This commit syncs up the Git repo with the revision at https://hackage.haskell.org/package/hint-0.7.0/revisions/

NB: There is no need for a new release due to this; the meta-data on Hackage has been already fixed.

