### PR TITLE
support ghc 8.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 matrix:
   include:
-    - env: CABALVER=1.22 GHCVER=7.10.3
-      addons: {apt: {packages: [cabal-install-1.22, ghc-7.10.3], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.2
       addons: {apt: {packages: [cabal-install-1.24, ghc-8.0.2],  sources: [hvr-ghc]}}
     - env: CABALVER=2.0  GHCVER=8.2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,10 @@ matrix:
       addons: {apt: {packages: [cabal-install-1.24, ghc-8.0.2],  sources: [hvr-ghc]}}
     - env: CABALVER=2.0  GHCVER=8.2.2
       addons: {apt: {packages: [cabal-install-2.0,  ghc-8.2.2],  sources: [hvr-ghc]}}
-    - env: CABALVER=2.0  GHCVER=8.2.2 DYNAMIC=--enable-executable-dynamic
-      addons: {apt: {packages: [cabal-install-2.0,  ghc-8.2.2],  sources: [hvr-ghc]}}
+    - env: CABALVER=2.2  GHCVER=8.4.1
+      addons: {apt: {packages: [cabal-install-2.2,  ghc-8.4.1],  sources: [hvr-ghc]}}
+    - env: CABALVER=2.2  GHCVER=8.4.1 DYNAMIC=--enable-executable-dynamic
+      addons: {apt: {packages: [cabal-install-2.2,  ghc-8.4.1],  sources: [hvr-ghc]}}
 
 before_install:
   - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 * Add `runStmt` for executing statements in the `IO` monad and binding new names.
 
+### 0.8.0
+
+* Support GHC 8.4
+* Drop support for GHC 7.10
+* Internal changes of temporary files for phantom modules
+  - The files are now called `M<nnn>.hs` instead of `<nnn>`
+  - Improved cleanup of phantom module source files
+  - ghc 8.4 only: phantom modules are put into a temporary directory
+
 ### 0.7.0
 
 * Support for GHC 8.2

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ It is, essentially, a huge subset of the GHC API wrapped in a simpler
 API.
 
 Compatibility is kept with the three last major GHC releases. For
-example, if the current version is GHC 8.2, Hint will work on 8.2, 8.0
-and 7.10.
+example, if the current version is GHC 8.4, Hint will work on 8.4, 8.2
+and 8.0.
 
 ### Example
 

--- a/hint.cabal
+++ b/hint.cabal
@@ -57,6 +57,12 @@ library
       build-depends: ghc-boot
   }
 
+  if impl(ghc >= 8.4 && < 8.6) {
+      build-depends: temporary
+      cpp-options: -DNEED_PHANTOM_DIRECTORY
+  }
+
+
   if !os(windows) {
       build-depends: unix >= 2.2.0.0
   }

--- a/hint.cabal
+++ b/hint.cabal
@@ -1,5 +1,5 @@
 name:         hint
-version:      0.7.0
+version:      0.8.0
 description:
         This library defines an Interpreter monad. It allows to load Haskell
         modules, browse them, type-check and evaluate strings with Haskell
@@ -45,23 +45,19 @@ test-suite unit-tests
 
 library
   build-depends: base == 4.*,
-                 ghc >= 7.10 && < 8.6,
+                 ghc >= 8.0 && < 8.6,
                  ghc-paths,
+                 ghc-boot,
                  mtl,
                  filepath,
                  exceptions == 0.8.*,
                  random,
                  directory
 
-  if impl(ghc >= 8.0) {
-      build-depends: ghc-boot
-  }
-
   if impl(ghc >= 8.4 && < 8.6) {
       build-depends: temporary
       cpp-options: -DNEED_PHANTOM_DIRECTORY
   }
-
 
   if !os(windows) {
       build-depends: unix >= 2.2.0.0

--- a/hint.cabal
+++ b/hint.cabal
@@ -45,13 +45,17 @@ test-suite unit-tests
 
 library
   build-depends: base == 4.*,
-                 ghc >= 7.10 && < 8.4,
+                 ghc >= 7.10 && < 8.6,
                  ghc-paths,
                  mtl,
                  filepath,
                  exceptions == 0.8.*,
                  random,
                  directory
+
+  if impl(ghc >= 8.0) {
+      build-depends: ghc-boot
+  }
 
   if !os(windows) {
       build-depends: unix >= 2.2.0.0

--- a/src/Control/Monad/Ghc.hs
+++ b/src/Control/Monad/Ghc.hs
@@ -25,11 +25,7 @@ instance (Functor m, Monad m) => Applicative (GhcT m) where
   pure  = return
   (<*>) = ap
 
-#if __GLASGOW_HASKELL__ >= 800
 runGhcT :: (MonadIO m, MonadMask m) => Maybe FilePath -> GhcT m a -> m a
-#else
-runGhcT :: (Functor m, MonadIO m, MonadCatch m, MonadMask m) => Maybe FilePath -> GhcT m a -> m a
-#endif
 runGhcT f = unMTLA . GHC.runGhcT f . unGhcT
 
 instance MTL.MonadTrans GhcT where

--- a/src/Hint/Annotations.hs
+++ b/src/Hint/Annotations.hs
@@ -6,7 +6,11 @@ module Hint.Annotations (
 import Control.Monad
 import Data.Data
 import Annotations
+#if __GLASGOW_HASKELL__ >= 800
+import GHC.Serialized
+#else
 import Serialized
+#endif
 
 import Hint.Base
 import HscTypes (hsc_mod_graph, ms_mod)
@@ -15,7 +19,7 @@ import qualified Hint.GHC as GHC
 -- Get the annotations associated with a particular module.
 getModuleAnnotations :: (Data a, MonadInterpreter m) => a -> String -> m [a]
 getModuleAnnotations _ x = do
-    mods <- liftM hsc_mod_graph $ runGhc GHC.getSession
+    mods <- liftM (GHC.mgModSummaries . hsc_mod_graph) $ runGhc GHC.getSession
     let x' = filter ((==) x . GHC.moduleNameString . GHC.moduleName . ms_mod) mods
     v <- mapM (anns . ModuleTarget . ms_mod) x'
     return $ concat v

--- a/src/Hint/Annotations.hs
+++ b/src/Hint/Annotations.hs
@@ -6,11 +6,7 @@ module Hint.Annotations (
 import Control.Monad
 import Data.Data
 import Annotations
-#if __GLASGOW_HASKELL__ >= 800
 import GHC.Serialized
-#else
-import Serialized
-#endif
 
 import Hint.Base
 import HscTypes (hsc_mod_graph, ms_mod)

--- a/src/Hint/Base.hs
+++ b/src/Hint/Base.hs
@@ -60,6 +60,9 @@ data InterpreterError = UnknownError String
 data InterpreterState = St {
                            activePhantoms    :: [PhantomModule],
                            zombiePhantoms    :: [PhantomModule],
+#if defined(NEED_PHANTOM_DIRECTORY)
+                           phantomDirectory  :: Maybe FilePath,
+#endif
                            hintSupportModule :: PhantomModule,
                            importQualHackMod :: Maybe PhantomModule,
                            qualImports       :: [ModuleImport],

--- a/src/Hint/Base.hs
+++ b/src/Hint/Base.hs
@@ -205,8 +205,9 @@ findModule mn = mapGhcExceptions NotAllowed $
 moduleIsLoaded :: MonadInterpreter m => ModuleName -> m Bool
 moduleIsLoaded mn = (findModule mn >> return True)
                    `catchIE` (\e -> case e of
-                                      NotAllowed{} -> return False
-                                      _            -> throwM e)
+                                      NotAllowed{}  -> return False
+                                      WontCompile{} -> return False
+                                      _             -> throwM e)
 
 withDynFlags :: MonadInterpreter m => (GHC.DynFlags -> m a) -> m a
 withDynFlags action

--- a/src/Hint/Base.hs
+++ b/src/Hint/Base.hs
@@ -32,9 +32,9 @@ import Hint.Extension
 
 -- | Version of the underlying ghc api. Values are:
 --
--- * @710@ for GHC 7.10.x
+-- * @802@ for GHC 8.2.x
 --
--- * @800@ for GHC 8.0.x
+-- * @804@ for GHC 8.4.x
 --
 -- * etc...
 ghcVersion :: Int
@@ -98,27 +98,15 @@ instance Exception InterpreterError
     displayException (GhcException err) = "GhcException: " ++ err
 
 type RunGhc  m a =
-#if __GLASGOW_HASKELL__ >= 800
     (forall n.(MonadIO n, MonadMask n) => GHC.GhcT n a)
-#else
-    (forall n.(MonadIO n, MonadMask n, Functor n) => GHC.GhcT n a)
-#endif
  -> m a
 
 type RunGhc1 m a b =
-#if __GLASGOW_HASKELL__ >= 800
     (forall n.(MonadIO n, MonadMask n) => a -> GHC.GhcT n b)
-#else
-    (forall n.(MonadIO n, MonadMask n, Functor n) => a -> GHC.GhcT n b)
-#endif
  -> (a -> m b)
 
 type RunGhc2 m a b c =
-#if __GLASGOW_HASKELL__ >= 800
     (forall n.(MonadIO n, MonadMask n) => a -> b -> GHC.GhcT n c)
-#else
-    (forall n.(MonadIO n, MonadMask n, Functor n) => a -> b -> GHC.GhcT n c)
-#endif
  -> (a -> b -> m c)
 
 data SessionData a = SessionData {

--- a/src/Hint/Configuration.hs
+++ b/src/Hint/Configuration.hs
@@ -17,6 +17,9 @@ module Hint.Configuration (
 import Control.Monad
 import Control.Monad.Catch
 import Data.Char
+#if defined(NEED_PHANTOM_DIRECTORY)
+import Data.Maybe (maybe)
+#endif
 import Data.List (intercalate)
 
 import qualified Hint.GHC as GHC
@@ -121,6 +124,11 @@ searchPath = Option setter getter
           setter p = do onConf $ \c -> c{searchFilePath = p}
                         setGhcOption "-i" -- clear the old path
                         setGhcOption $ "-i" ++ intercalate ":" p
+#if defined(NEED_PHANTOM_DIRECTORY)
+                        mfp <- fromState phantomDirectory
+                        maybe (return ())
+                              (\fp -> setGhcOption $ "-i" ++ fp) mfp
+#endif
 
 fromConf :: MonadInterpreter m => (InterpreterConfiguration -> a) -> m a
 fromConf f = fromState (f . configuration)

--- a/src/Hint/Context.hs
+++ b/src/Hint/Context.hs
@@ -181,7 +181,7 @@ removePhantomModule pm =
        if safeToRemove
          then do mayFail $ do res <- runGhc1 GHC.load GHC.LoadAllTargets
                               return $ guard (isSucceeded res) >> Just ()
-                 liftIO $ removeFile (pmFile pm)
+              `finally` do liftIO $ removeFile (pmFile pm)
          else onState (\s -> s{zombiePhantoms = pm:zombiePhantoms s})
 
 -- Returns a tuple with the active and zombie phantom modules respectively

--- a/src/Hint/Eval.hs
+++ b/src/Hint/Eval.hs
@@ -67,21 +67,12 @@ eval expr = do in_scope_show   <- supportShow
 runStmt :: (MonadInterpreter m) => String -> m ()
 runStmt = mayFail . runGhc1 go
     where
-#if __GLASGOW_HASKELL__ >= 800
     go statements = do
         result <- GHC.execStmt statements GHC.execOptions
         return $ case result of
             GHC.ExecComplete { GHC.execResult = Right _ } -> Just ()
             GHC.ExecComplete { GHC.execResult = Left  e } -> throw e
             _                                             -> Nothing
-#else
-    go statements = do
-        result <- GHC.runStmt statements GHC.RunToCompletion
-        return $ case result of
-            GHC.RunOk _        -> Just ()
-            GHC.RunException e -> throw e
-            _                  -> Nothing
-#endif
 
 -- | Conceptually, @parens s = \"(\" ++ s ++ \")\"@, where s is any valid haskell
 -- expression. In practice, it is harder than this.

--- a/src/Hint/GHC.hs
+++ b/src/Hint/GHC.hs
@@ -1,11 +1,17 @@
 module Hint.GHC (
-    Message, module X
+    Message, module X,
+#if __GLASGOW_HASKELL__ < 804
+    GhcPs, mgModSummaries
+#endif
 ) where
 
 import GHC as X hiding (Phase, GhcT, runGhcT)
 import Control.Monad.Ghc as X (GhcT, runGhcT)
 
 import HscTypes as X (SourceError, srcErrorMessages, GhcApiError)
+#if __GLASGOW_HASKELL__ >= 804
+import HscTypes as X (mgModSummaries)
+#endif
 
 import Outputable as X (PprStyle, SDoc, Outputable(ppr),
                         showSDoc, showSDocForUser, showSDocUnqual,
@@ -33,3 +39,10 @@ import ConLike as X (ConLike(RealDataCon))
 import DynFlags as X (addWay', Way(..), dynamicGhc)
 
 type Message = MsgDoc
+
+#if __GLASGOW_HASKELL__ < 804
+type GhcPs = RdrName
+
+mgModSummaries :: ModuleGraph -> [ModSummary]
+mgModSummaries = id
+#endif

--- a/src/Hint/GHC.hs
+++ b/src/Hint/GHC.hs
@@ -27,9 +27,7 @@ import FastString as X (fsLit)
 
 import DynFlags as X (xFlags, xopt, LogAction, FlagSpec(..))
 
-#if __GLASGOW_HASKELL__ >= 800
 import DynFlags as X (WarnReason(NoReason))
-#endif
 
 import PprTyThing as X (pprTypeForUser)
 import SrcLoc as X (mkRealSrcLoc)

--- a/src/Hint/InterpreterT.hs
+++ b/src/Hint/InterpreterT.hs
@@ -176,6 +176,9 @@ initialState :: InterpreterState
 initialState = St {
                    activePhantoms    = [],
                    zombiePhantoms    = [],
+#if defined(NEED_PHANTOM_DIRECTORY)
+                   phantomDirectory  = Nothing,
+#endif
                    hintSupportModule = error "No support module loaded!",
                    importQualHackMod = Nothing,
                    qualImports       = [],

--- a/src/Hint/Parsers.hs
+++ b/src/Hint/Parsers.hs
@@ -29,7 +29,12 @@ runParser parser expr =
        case parse_res of
            GHC.POk{}            -> return ParseOk
            --
-           GHC.PFailed span err -> return (ParseError span err)
+#if __GLASGOW_HASKELL__ >= 804
+           GHC.PFailed _ span err
+#else
+           GHC.PFailed span err
+#endif
+                                -> return (ParseError span err)
 
 failOnParseError :: MonadInterpreter m
                  => (String -> m ParseResult)

--- a/src/Hint/Parsers.hs
+++ b/src/Hint/Parsers.hs
@@ -56,9 +56,7 @@ failOnParseError parser expr = mayFail go
                              let logger'  = logger dflags
                                  errStyle = GHC.defaultErrStyle dflags
                              liftIO $ logger'
-#if __GLASGOW_HASKELL__ >= 800
                                               GHC.NoReason
-#endif
                                               GHC.SevError
                                               span
                                               errStyle

--- a/src/Language/Haskell/Interpreter/Unsafe.hs
+++ b/src/Language/Haskell/Interpreter/Unsafe.hs
@@ -24,11 +24,8 @@ unsafeSetGhcOption = setGhcOption
 --   context.
 --
 --   Warning: Some options may interact badly with the Interpreter.
-unsafeRunInterpreterWithArgs :: (MonadMask m, MonadIO m
-#if __GLASGOW_HASKELL__ < 800
-                                 , Functor m
-#endif
-                             ) => [String]
+unsafeRunInterpreterWithArgs :: (MonadMask m, MonadIO m)
+                             => [String]
                              -> InterpreterT m a
                              -> m (Either InterpreterError a)
 unsafeRunInterpreterWithArgs = runInterpreterWithArgs
@@ -39,11 +36,8 @@ unsafeRunInterpreterWithArgs = runInterpreterWithArgs
 --   a machine in which GHC is not installed.
 --
 --   A typical libdir value could be "/usr/lib/ghc-8.0.1/ghc-8.0.1".
-unsafeRunInterpreterWithArgsLibdir :: (MonadIO m, MonadMask m
-#if __GLASGOW_HASKELL__ < 800
-                                 , Functor m
-#endif
-                                   ) => [String]
+unsafeRunInterpreterWithArgsLibdir :: (MonadIO m, MonadMask m)
+                                   => [String]
                                    -> String
                                    -> InterpreterT m a
                                    -> m (Either InterpreterError a)


### PR DESCRIPTION
relevant changes in ghc:

- `Serialized` has been available as `GHC.Serialized` in ghc-boot since
  ghc-8.0; it is no longer reexported from the ghc package.
- `HscTypes.ModuleGraph` is now a proper data type rather than an alias for
  `[HscTypes.ModSummary]`; one needs to use `HscTypes.mgModSummaries` to
  extract the list of dependencies
- `RdrName` is now called `GhcPs`
- `Lexer.PFailed` has a new extra field
- something in the error handling of `findModule` has changed so that
  `WontCompile` errors can turn up in `moduleIsLoaded`

Note that this overlaps slightly with #53 which also bumps the ghc dependency. I've left the travis build alone for that reason.